### PR TITLE
Includes Taxjar Advanced Api and Calculate Shipment Sales Tax & other fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ spec/dummy
 .rvmrc
 .ruby-version
 .ruby-gemset
+.byebug_history

--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,6 @@ gem 'spree', github: 'spree/spree', branch: '3-1-stable'
 gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: '3-1-stable'
 group :test do
   gem 'rails-controller-testing'
+  gem 'byebug'
 end
 gemspec

--- a/README.md
+++ b/README.md
@@ -1,27 +1,34 @@
 SpreeTaxjar
 ===========
 
-Spree::Taxjar is a US sales tax extension for Spree using the Taxjar service.
+Spree::Taxjar is a Sales Tax extension for Spree using the [Taxjar Service](https://developers.taxjar.com/api/reference/).
 
-Taxjar Configuration
+## Prerequisite
 
-Create an account with Taxjar (http://www.taxjar.com/) and get an api_key.
-
-Go to Your Account >> States Setting, and create nexus for the relevant states in which you want/need to collect sales tax. (NOTE: Unless state's nexuses are explicitly created, Taxjar will return zero sales tax by default for orders shipping to those states.)
+- Create an account with [Taxjar](http://www.taxjar.com/)
+- Go to Your `Account >> SmartCalcs Api` Setting and Get an API Key
+    - API key is needed to calculate sales tax from Taxjar over API
+- Go to Your `Account >> States` Setting, and create [Nexus](http://blog.taxjar.com/sales-tax-nexus-definition/) for the relevant states in which you want/need to collect sales tax.
+    - **NOTE:** Taxjar returns ZERO sales tax by default for orders shipping to the states which are not registered as Nexuses.
 
 ## Installation
 
 1. Add this extension to your Gemfile with this line:
+
   ```ruby
-  gem 'spree_taxjar', github: 'vinsol-spree-contrib/spree_taxjar'
+  gem 'spree_taxjar', github: 'vinsol-spree-contrib/spree_taxjar', branch: <spree-version-compatible>
   ```
+  
+  *The `branch` option is important:* it must match the version of Spree you're using. For example, use `3-1-stable` if you're using Spree `3-1-stable` or any `3.1.x` version.
 
 2. Install the gem using Bundler:
+
   ```ruby
   bundle install
   ```
 
 3. Copy & run migrations
+
   ```ruby
   bundle exec rails g spree_taxjar:install
   ```
@@ -30,8 +37,35 @@ Go to Your Account >> States Setting, and create nexus for the relevant states i
 
   If your server was running, restart it so that it can find the assets properly.
 
-5. Go to admin end > Configurations > Taxjar Settings
-  Add your taxjar api_key here.
+5. Go to Admin >> Configurations >> Taxjar Settings
+  - Add your taxjar api_key.
+  - Check `TAXJAR ENABLED`
+  - You can optionally also check `TAXJAR DEBUG ENABLED` but its not recommended for production unless need help debugging production issue.
+
+## Developing / Debugging Extension
+
+- Ensure `Spree::Config[:taxjar_enabled]` is set as expected (true/false)
+- Set `Spree::Config[:taxjar_debug_enabled]` as true
+    - It starts logging the interactions in `spec/dummy/log/spree_taxjar.log` if    using tests
+    - Check the logs in your Rails application AT `log/spree_taxjar.log` where you have installed the spree_taxjar extension
+    - The same logs are also added to Rails log file like `log/development.log` (works for all environments)
+- As most of the API interactions are recorded and stored in vcr cassettes AT `spec/fixtures/vcr_cassettes`
+    - Start with getting familiar with request and response expected
+    - Feel free to delete the cassettes to debug your live use-case by setting `Spree::Config[:taxjar_api_key]` as your api_key and inspect results
+
+## API cost and implication to Taxjar Billing Plan
+
+- We have chosen accuracy over price for obvious reasons (high fine by states if sales tax compliance breach is found)
+- Minimum of N + 1 tax calculation API calls are made for each order with N shipments
+
+### Why
+
+Taxjar provides 2 set of API tiers (Standard and Advanced) but shipping in both cases is sent as single unit which makes Sales Tax calculation for different shipments a bit tricky or hacky
+
+- We chose to use both API methods at our advantage
+- For line\_items sales tax, Advanced Tier API call is made to take advantage of in-built product_tax_code and discount fields and all line_items are grouped and sent in same API call
+    - Shipping component is ignored as it returns tax for whole order shipping cost and not shipment wise
+- For shipments, standard tier API call is made for each shipment with order amount as ZERO and shipping as shipment cost as we are only interested in shipping charge and not the whole order tax which solves the problem of inaccurate and hackish implementation.
 
 ## Testing
 

--- a/app/controllers/spree/admin/taxjar_settings_controller.rb
+++ b/app/controllers/spree/admin/taxjar_settings_controller.rb
@@ -2,13 +2,14 @@ module Spree
   module Admin
     class TaxjarSettingsController < Spree::Admin::BaseController
       def edit
-        @preferences_api = [:taxjar_api_key]
+        @preferences_api = [:taxjar_api_key, :taxjar_enabled]
       end
 
       def update
         Spree::Config[:taxjar_api_key] = params[:taxjar_api_key]
+        Spree::Config[:taxjar_enabled] = params[:taxjar_enabled]
 
-        flash[:success] = Spree.t(:api_key_updated)
+        flash[:success] = Spree.t(:taxjar_settings_updated)
         redirect_to edit_admin_taxjar_settings_path
       end
 

--- a/app/controllers/spree/admin/taxjar_settings_controller.rb
+++ b/app/controllers/spree/admin/taxjar_settings_controller.rb
@@ -2,12 +2,13 @@ module Spree
   module Admin
     class TaxjarSettingsController < Spree::Admin::BaseController
       def edit
-        @preferences_api = [:taxjar_api_key, :taxjar_enabled]
+        @preferences_api = [:taxjar_api_key, :taxjar_enabled, :taxjar_debug_enabled]
       end
 
       def update
         Spree::Config[:taxjar_api_key] = params[:taxjar_api_key]
         Spree::Config[:taxjar_enabled] = params[:taxjar_enabled]
+        Spree::Config[:taxjar_debug_enabled] = params[:taxjar_debug_enabled]
 
         flash[:success] = Spree.t(:taxjar_settings_updated)
         redirect_to edit_admin_taxjar_settings_path

--- a/app/helpers/taxjar_helper.rb
+++ b/app/helpers/taxjar_helper.rb
@@ -1,0 +1,63 @@
+module TaxjarHelper
+  class Pretty < Logger::Formatter
+    # Provide a call() method that returns the formatted message.
+    def call(severity, time, program_name, message)
+      "#{time.utc.iso8601} #{Process.pid} TID-#{Thread.current.object_id.to_s(36)}#{context} #{severity}: #{message}\n"
+    end
+
+    def context
+      Thread.current[:spree_taxjar_context] ? " #{c}" : ''
+    end
+  end
+
+  class TaxjarLog
+    def initialize(path_name, file_name, log_info = nil, schedule = nil)
+      schedule = "weekly" unless schedule != nil
+      @logger ||= Logger.new("#{Rails.root}/log/#{path_name}.log", schedule)
+      @logger.formatter = Pretty.new
+      progname(file_name.split("/").last.chomp(".rb"))
+      info(log_info) unless log_info.nil?
+    end
+
+    def logger
+      @logger
+    end
+
+    def logger_enabled?
+      true
+    end
+
+    def progname(progname = nil)
+      progname.nil? ? logger.progname : logger.progname = progname
+    end
+
+    def info(log_info = nil)
+      if logger_enabled?
+        logger.info log_info unless log_info.nil?
+      end
+    end
+
+    def info_and_debug(log_info, response)
+      if logger_enabled?
+        logger.info log_info
+        if response.is_a?(Hash)
+          logger.debug JSON.generate(response)
+        else
+          logger.debug response
+        end
+      end
+    end
+
+    def debug(error, text = nil)
+      if logger_enabled?
+        logger.debug error
+        if text.nil?
+          error
+        else
+          logger.debug text
+          text
+        end
+      end
+    end
+  end
+end

--- a/app/helpers/taxjar_helper.rb
+++ b/app/helpers/taxjar_helper.rb
@@ -59,5 +59,12 @@ module TaxjarHelper
         end
       end
     end
+
+    def log(method, request_hash = nil)
+      logger.info method.to_s + ' call'
+      return if request_hash.nil?
+      logger.debug request_hash
+      logger.debug JSON.generate(request_hash)
+    end
   end
 end

--- a/app/helpers/taxjar_helper.rb
+++ b/app/helpers/taxjar_helper.rb
@@ -24,7 +24,7 @@ module TaxjarHelper
     end
 
     def logger_enabled?
-      true
+      Spree::Config[:taxjar_debug_enabled]
     end
 
     def progname(progname = nil)

--- a/app/helpers/taxjar_helper.rb
+++ b/app/helpers/taxjar_helper.rb
@@ -11,16 +11,13 @@ module TaxjarHelper
   end
 
   class TaxjarLog
-    def initialize(path_name, file_name, log_info = nil, schedule = nil)
-      schedule = "weekly" unless schedule != nil
+    attr_reader :logger
+
+    def initialize(path_name, file_name, log_info = nil, schedule = "weekly")
       @logger ||= Logger.new("#{Rails.root}/log/#{path_name}.log", schedule)
       @logger.formatter = Pretty.new
       progname(file_name.split("/").last.chomp(".rb"))
       info(log_info) unless log_info.nil?
-    end
-
-    def logger
-      @logger
     end
 
     def logger_enabled?

--- a/app/models/spree/app_configuration_decorator.rb
+++ b/app/models/spree/app_configuration_decorator.rb
@@ -1,3 +1,4 @@
 Spree::AppConfiguration.class_eval do
   preference :taxjar_api_key, :string
+  preference :taxjar_enabled, :boolean, default: false
 end

--- a/app/models/spree/app_configuration_decorator.rb
+++ b/app/models/spree/app_configuration_decorator.rb
@@ -1,4 +1,5 @@
 Spree::AppConfiguration.class_eval do
   preference :taxjar_api_key, :string
   preference :taxjar_enabled, :boolean, default: false
+  preference :taxjar_debug_enabled, :boolean, default: false
 end

--- a/app/models/spree/calculator/taxjar_calculator.rb
+++ b/app/models/spree/calculator/taxjar_calculator.rb
@@ -15,6 +15,7 @@ module Spree
     end
 
     def compute_line_item(item)
+      return 0 unless Spree::Config[:taxjar_enabled]
       if rate.included_in_price
         0
       else
@@ -23,10 +24,12 @@ module Spree
     end
 
     def compute_shipment(item)
+      return 0 unless Spree::Config[:taxjar_enabled]
       tax_for_shipment(item)
     end
 
     def compute_shipping_rate(shipping_rate)
+      return 0 unless Spree::Config[:taxjar_enabled]
       if rate.included_in_price
         raise Spree.t(:shipping_rate_exception_message)
       else

--- a/app/models/spree/calculator/taxjar_calculator.rb
+++ b/app/models/spree/calculator/taxjar_calculator.rb
@@ -15,6 +15,7 @@ module Spree
     end
 
     def compute_line_item(item)
+      SpreeTaxjar::Logger.log(__method__, {line_item: {order: {id: item.order.id, number: item.order.number}}}) if SpreeTaxjar::Logger.logger_enabled?
       return 0 unless Spree::Config[:taxjar_enabled]
       if rate.included_in_price
         0
@@ -23,9 +24,10 @@ module Spree
       end
     end
 
-    def compute_shipment(item)
+    def compute_shipment(shipment)
+      SpreeTaxjar::Logger.log(__method__, {shipment: {order: {id: shipment.order.id, number: shipment.order.number}}}) if SpreeTaxjar::Logger.logger_enabled?
       return 0 unless Spree::Config[:taxjar_enabled]
-      tax_for_shipment(item)
+      tax_for_shipment(shipment)
     end
 
     def compute_shipping_rate(shipping_rate)
@@ -46,7 +48,11 @@ module Spree
         order = shipment.order
         return 0 unless tax_address = order.tax_address
 
-        Rails.cache.fetch(cache_key(order, shipment, tax_address), expires_in: CACHE_EXPIRATION_DURATION) do
+        rails_cache_key = cache_key(order, shipment, tax_address)
+
+        SpreeTaxjar::Logger.log(__method__, {shipment: {order: {id: shipment.order.id, number: shipment.order.number}}, cache_key: rails_cache_key}) if SpreeTaxjar::Logger.logger_enabled?
+
+        Rails.cache.fetch(rails_cache_key, expires_in: CACHE_EXPIRATION_DURATION) do
           Spree::Taxjar.new(order, nil, shipment).calculate_tax_for_shipment
         end
       end
@@ -55,20 +61,35 @@ module Spree
         order = item.order
         return 0 unless tax_address = order.tax_address
 
-        unless Rails.cache.read(cache_key(order, item, tax_address))
+        rails_cache_key = cache_key(order, item, tax_address)
+
+        SpreeTaxjar::Logger.log(__method__, {line_item: {order: {id: item.order.id, number: item.order.number}}, cache_key: rails_cache_key}) if SpreeTaxjar::Logger.logger_enabled?
+
+        ## Test when caching enabled that only 1 API call is sent for an order
+        ## should avoid N calls for N line_items
+        Rails.cache.fetch(rails_cache_key, expires_in: CACHE_EXPIRATION_DURATION) do
           taxjar_response = Spree::Taxjar.new(order).calculate_tax_for_order
           return 0 unless taxjar_response
-          cache_response(taxjar_response, order, tax_address)
+          tax_for_current_item = cache_response(taxjar_response, order, tax_address, item)
+          tax_for_current_item
         end
-
-        Rails.cache.read(cache_key(order, item, tax_address))
       end
 
-      def cache_response(taxjar_response, order, address)
+      def cache_response(taxjar_response, order, address, item = nil)
+        SpreeTaxjar::Logger.log(__method__, {order: {id: order.id, number: order.number}, taxjar_api_advanced_res: taxjar_response}) if SpreeTaxjar::Logger.logger_enabled?
+        SpreeTaxjar::Logger.log(__method__, {order: {id: order.id, number: order.number}, taxjar_api_advanced_res: taxjar_response.breakdown.line_items}) if SpreeTaxjar::Logger.logger_enabled?
+        ## res is set to faciliate testing as to return computed result from API
+        ## for given line_item
+        ## better to use Rails.cache.fetch for order and wrapping lookup based on line_item id
+        res = nil
         taxjar_response.breakdown.line_items.each do |line_item|
-          item =  Spree::LineItem.find_by(id: line_item.id)
-          Rails.cache.write(cache_key(order, item, address), line_item.tax_collectable, expires_in: CACHE_EXPIRATION_DURATION)
+          item_from_db = Spree::LineItem.find_by(id: line_item.id)
+          if item && item_from_db.id == item.id
+            res = line_item.tax_collectable
+          end
+          Rails.cache.write(cache_key(order, item_from_db, address), line_item.tax_collectable, expires_in: CACHE_EXPIRATION_DURATION)
         end
+        res
       end
 
       def cache_key(order, item, address)

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -8,12 +8,14 @@ Spree::Order.class_eval do
   private
 
     def delete_taxjar_transaction
+      return unless Spree::Config[:taxjar_enabled]
       return unless taxjar_applicable?(self)
       client = Spree::Taxjar.new(self)
       client.delete_transaction_for_order
     end
 
     def capture_taxjar
+      return unless Spree::Config[:taxjar_enabled]
       return unless taxjar_applicable?(self)
       client = Spree::Taxjar.new(self)
       client.create_transaction_for_order

--- a/app/models/spree/reimbursment_decorator.rb
+++ b/app/models/spree/reimbursment_decorator.rb
@@ -5,6 +5,7 @@ Spree::Reimbursement.class_eval do
   state_machine.after_transition to: [:reimbursed], do: :remove_tax_for_returned_items
 
   def remove_tax_for_returned_items
+    return unless Spree::Config[:taxjar_enabled]
     return unless taxjar_applicable?(order)
     client = Spree::Taxjar.new(order, self)
     client.create_refund_transaction_for_order

--- a/app/models/spree/taxjar.rb
+++ b/app/models/spree/taxjar.rb
@@ -1,5 +1,6 @@
 module Spree
   class Taxjar
+    attr_reader :client, :order, :reimbursement, :shipment
 
     def initialize(order = nil, reimbursement = nil, shipment = nil)
       @order = order
@@ -44,10 +45,6 @@ module Spree
       end
     end
 
-    def nexus_states(nexus_regions)
-      nexus_regions.map { |record| record.region_code}
-    end
-
     def calculate_tax_for_order
       SpreeTaxjar::Logger.log(__method__, {order: {id: @order.id, number: @order.number}}) if SpreeTaxjar::Logger.logger_enabled?
       if has_nexus?
@@ -62,6 +59,10 @@ module Spree
     end
 
     private
+
+      def nexus_states(nexus_regions)
+        nexus_regions.map { |record| record.region_code}
+      end
 
       def tax_address_country_iso
         tax_address.country.iso

--- a/app/models/spree/taxjar.rb
+++ b/app/models/spree/taxjar.rb
@@ -23,8 +23,13 @@ module Spree
     end
 
     def calculate_tax_for_shipment
+      SpreeTaxjar::Logger.log(__method__, {shipment: {order: {id: @shipment.order.id, number: @shipment.order.number}}}) if SpreeTaxjar::Logger.logger_enabled?
       if has_nexus?
-        @client.tax_for_order(shipment_tax_params).amount_to_collect
+        api_params = shipment_tax_params
+        SpreeTaxjar::Logger.log(__method__, {shipment: {order: {id: @shipment.order.id, number: @shipment.order.number}, api_params: api_params}}) if SpreeTaxjar::Logger.logger_enabled?
+        api_response = @client.tax_for_order(api_params)
+        SpreeTaxjar::Logger.log(__method__, {shipment: {order: {id: @shipment.order.id, number: @shipment.order.number}, api_response: api_response}}) if SpreeTaxjar::Logger.logger_enabled?
+        api_response.amount_to_collect
       else
         0
       end
@@ -44,8 +49,13 @@ module Spree
     end
 
     def calculate_tax_for_order
+      SpreeTaxjar::Logger.log(__method__, {order: {id: @order.id, number: @order.number}}) if SpreeTaxjar::Logger.logger_enabled?
       if has_nexus?
-        @client.tax_for_order(tax_params)
+        api_params = tax_params
+        SpreeTaxjar::Logger.log(__method__, {order: {id: @order.id, number: @order.number}, api_params: api_params}) if SpreeTaxjar::Logger.logger_enabled?
+        api_response = @client.tax_for_order(api_params)
+        SpreeTaxjar::Logger.log(__method__, {order: {id: @order.id, number: @order.number}, api_response: api_response}) if SpreeTaxjar::Logger.logger_enabled?
+        api_response
       else
         0
       end

--- a/config/initializers/logger.rb
+++ b/config/initializers/logger.rb
@@ -1,0 +1,2 @@
+SpreeTaxjar::Logger = TaxjarHelper::TaxjarLog.new("spree_taxjar", "taxjar_calculator")
+SpreeTaxjar::Logger.logger.extend(ActiveSupport::Logger.broadcast(Rails.logger))

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,7 +1,8 @@
 en:
   spree:
-    api_key_updated: Taxjar Api Key successfully updated
+    taxjar_settings_updated: Taxjar Settings successfully updated
     shipping_rate_exception_message: TaxJar cannot calculate inclusive sales taxes.
     taxjar_api_key: Taxjar API Key
+    taxjar_enabled: Enable Taxjar Calculation
     taxjar_calculator_description: Taxjar Calculator
     taxjar_settings: Taxjar Settings

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,5 +4,6 @@ en:
     shipping_rate_exception_message: TaxJar cannot calculate inclusive sales taxes.
     taxjar_api_key: Taxjar API Key
     taxjar_enabled: Enable Taxjar Calculation
+    taxjar_debug_enabled: Enable Taxjar Debug Logging
     taxjar_calculator_description: Taxjar Calculator
     taxjar_settings: Taxjar Settings

--- a/lib/spree_taxjar/categories.rb
+++ b/lib/spree_taxjar/categories.rb
@@ -1,0 +1,66 @@
+module SpreeTaxjar
+  class Categories
+    class << self
+      def update(tax_categories = [])
+        tax_categories = default_tax_categories if tax_categories.empty?
+        tax_categories.each do |tax_category|
+          tax_category_attributes = convert_to_hash(tax_category)
+          tax_category_in_db = Spree::TaxCategory.where(name: name(tax_category_attributes)).first
+          if tax_category_in_db.present?
+            p "TaxCategory:: Update:: #{tax_category_in_db.inspect}"
+            tax_category_in_db.update_attributes!(transform(tax_category_attributes))
+          else
+            new_tax_category = Spree::TaxCategory.create!(transform(tax_category_attributes))
+            p "TaxCategory:: Create:: #{new_tax_category.inspect}"
+          end
+        end
+      end
+
+      def refresh
+        p "Taxjar:: Categories:: API Call started !!"
+        client = ::Taxjar::Client.new(api_key: Spree::Config[:taxjar_api_key])
+        tax_categories = client.categories
+        p "Taxjar:: Categories:: Update Started"
+        update(tax_categories)
+      end
+
+      private
+        def convert_to_hash(tax_category)
+          tax_category.to_h
+        end
+
+        def transform(tax_category)
+          {name: name(tax_category), tax_code: tax_code(tax_category), description: description(tax_category)}
+        end
+
+        def name(tax_category)
+          tax_category.fetch(:name)
+        end
+
+        def tax_code(tax_category)
+          tax_category.fetch(:product_tax_code)
+        end
+
+        def description(tax_category)
+          tax_category.fetch(:description)
+        end
+
+        def default_tax_categories
+          [
+            {:name=>"Digital Goods", :product_tax_code=>"31000", :description=>"Digital products transferred electronically, meaning obtained by the purchaser by means other than tangible storage media."},
+            {:name=>"Clothing", :product_tax_code=>"20010", :description=>" All human wearing apparel suitable for general use"},
+            {:name=>"Non-Prescription", :product_tax_code=>"51010", :description=>"Drugs for human use without a prescription"},
+            {:name=>"Prescription", :product_tax_code=>"51020", :description=>"Drugs for human use with a prescription"},
+            {:name=>"Food & Groceries", :product_tax_code=>"40030", :description=>"Food for humans consumption, unprepared"},
+            {:name=>"Other Exempt", :product_tax_code=>"99999", :description=>"Item is exempt"},
+            {:name=>"Software as a Service", :product_tax_code=>"30070", :description=>"Pre-written software, delivered electronically, but access remotely."},
+            {:name=>"Magazines & Subscriptions", :product_tax_code=>"81300", :description=>"Periodicals, printed, sold by subscription"},
+            {:name=>"Books", :product_tax_code=>"81100", :description=>"Books, printed"},
+            {:name=>"Magazine", :product_tax_code=>"81310", :description=>"Periodicals, printed, sold individually"},
+            {:name=>"Textbook", :product_tax_code=>"81110", :description=>"Textbooks, printed"},
+            {:name=>"Religious books", :product_tax_code=>"81120", :description=>"Religious books and manuals, printed"}
+          ]
+        end
+    end
+  end
+end

--- a/lib/spree_taxjar/engine.rb
+++ b/lib/spree_taxjar/engine.rb
@@ -3,6 +3,8 @@ module SpreeTaxjar
     require 'spree/core'
     require 'taxjar'
 
+    config.autoload_paths += %W(#{config.root}/lib)
+
     isolate_namespace Spree
     engine_name 'spree_taxjar'
 

--- a/lib/tasks/load_tax_categories.rake
+++ b/lib/tasks/load_tax_categories.rake
@@ -1,0 +1,11 @@
+namespace :spree_taxjar do
+  desc 'Load Taxjar Categories'
+  task load_categories: :environment do
+    SpreeTaxjar::Categories.update
+  end
+
+  desc 'Refresh Taxjar Categories'
+  task refresh_categories: :environment do
+    SpreeTaxjar::Categories.refresh
+  end
+end

--- a/spec/controllers/spree/admin/taxjar_settings_controller_spec.rb
+++ b/spec/controllers/spree/admin/taxjar_settings_controller_spec.rb
@@ -21,7 +21,7 @@ describe Spree::Admin::TaxjarSettingsController, type: :controller do
     end
 
     it "assigns @preferences_api" do
-      expect(assigns[:preferences_api]).to eq([:taxjar_api_key])
+      expect(assigns[:preferences_api]).to eq([:taxjar_api_key, :taxjar_enabled, :taxjar_debug_enabled])
     end
 
     it "renders edit template" do
@@ -33,7 +33,7 @@ describe Spree::Admin::TaxjarSettingsController, type: :controller do
   describe "PUT 'update'" do
 
     def send_request
-      put :update, taxjar_api_key: 'SAMPLE_API_KEY'
+      put :update, taxjar_api_key: 'SAMPLE_API_KEY', taxjar_enabled: '1', taxjar_debug_enabled: '1'
     end
 
     before do
@@ -44,8 +44,16 @@ describe Spree::Admin::TaxjarSettingsController, type: :controller do
       expect(Spree::Config[:taxjar_api_key]).to eq 'SAMPLE_API_KEY'
     end
 
+    it "saves taxjar_enabled with passed parameter" do
+      expect(Spree::Config[:taxjar_enabled]).to be(true)
+    end
+
+    it "saves taxjar_debug_enabled with passed parameter" do
+      expect(Spree::Config[:taxjar_debug_enabled]).to be(true)
+    end
+
     it "sets flash message to success" do
-      expect(flash[:success]).to eq Spree.t(:api_key_updated)
+      expect(flash[:success]).to eq Spree.t(:taxjar_settings_updated)
     end
 
     it "renders edit template" do

--- a/spec/fixtures/vcr_cassettes/compute_shipment_with_california_address.yml
+++ b/spec/fixtures/vcr_cassettes/compute_shipment_with_california_address.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.taxjar.com/v2/nexus/regions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - TaxjarRubyGem/1.5.0
+      Authorization:
+      - Bearer 04d828b7374896d7867b03289ea20957
+      Connection:
+      - close
+      Host:
+      - api.taxjar.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Sun, 15 Jan 2017 13:34:23 GMT
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+      Vary:
+      - Origin
+      Etag:
+      - W/"447b75f14eaedf6b3e59ea269af620e4"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - a66e775b-1f61-4ead-bb4f-f0f6ba789d96
+      X-Runtime:
+      - '0.017805'
+      Content-Length:
+      - '186'
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"regions":[{"country_code":"US","country":"United States","region_code":"CA","region":"California"},{"country_code":"US","country":"United
+        States","region_code":"TX","region":"Texas"}]}'
+    http_version: 
+  recorded_at: Sun, 15 Jan 2017 13:34:23 GMT
+- request:
+    method: post
+    uri: https://api.taxjar.com/v2/taxes
+    body:
+      encoding: UTF-8
+      string: '{"to_country":"US","to_zip":"90002","to_state":"CA","to_city":"Los
+        Angeles","amount":0,"shipping":"10.0"}'
+    headers:
+      User-Agent:
+      - TaxjarRubyGem/1.5.0
+      Authorization:
+      - Bearer 04d828b7374896d7867b03289ea20957
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+      Host:
+      - api.taxjar.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Sun, 15 Jan 2017 13:34:26 GMT
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+      Vary:
+      - Origin
+      Etag:
+      - W/"6f9c7acc393cff4a65bed96c3bc131fc"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 9ad7d37b-e06d-4a57-9ca1-86f94ca8764c
+      X-Runtime:
+      - '0.029616'
+      Content-Length:
+      - '175'
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"tax":{"order_total_amount":10.0,"shipping":10.0,"taxable_amount":0.0,"amount_to_collect":0.0,"rate":0.0,"has_nexus":true,"freight_taxable":false,"tax_source":"destination"}}'
+    http_version: 
+  recorded_at: Sun, 15 Jan 2017 13:34:26 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/compute_shipment_with_texas_address.yml
+++ b/spec/fixtures/vcr_cassettes/compute_shipment_with_texas_address.yml
@@ -1,0 +1,100 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.taxjar.com/v2/nexus/regions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - TaxjarRubyGem/1.5.0
+      Authorization:
+      - Bearer 04d828b7374896d7867b03289ea20957
+      Connection:
+      - close
+      Host:
+      - api.taxjar.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Sun, 15 Jan 2017 13:34:17 GMT
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+      Vary:
+      - Origin
+      Etag:
+      - W/"447b75f14eaedf6b3e59ea269af620e4"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 3c44fded-97d6-4581-ba04-4d2e6353c980
+      X-Runtime:
+      - '0.011824'
+      Content-Length:
+      - '186'
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"regions":[{"country_code":"US","country":"United States","region_code":"CA","region":"California"},{"country_code":"US","country":"United
+        States","region_code":"TX","region":"Texas"}]}'
+    http_version: 
+  recorded_at: Sun, 15 Jan 2017 13:34:17 GMT
+- request:
+    method: post
+    uri: https://api.taxjar.com/v2/taxes
+    body:
+      encoding: UTF-8
+      string: '{"to_country":"US","to_zip":"79001","to_state":"TX","to_city":"Adrian","amount":0,"shipping":"10.0"}'
+    headers:
+      User-Agent:
+      - TaxjarRubyGem/1.5.0
+      Authorization:
+      - Bearer 04d828b7374896d7867b03289ea20957
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+      Host:
+      - api.taxjar.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Sun, 15 Jan 2017 13:34:20 GMT
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+      Vary:
+      - Origin
+      Etag:
+      - W/"6742d1b81d011bd53b4964999698dc16"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 59c26711-a200-448f-b3ff-22a62f9f5d8a
+      X-Runtime:
+      - '0.022650'
+      Content-Length:
+      - '174'
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"tax":{"order_total_amount":10.0,"shipping":10.0,"taxable_amount":10.0,"amount_to_collect":0.78,"rate":0.0775,"has_nexus":true,"freight_taxable":true,"tax_source":"origin"}}'
+    http_version: 
+  recorded_at: Sun, 15 Jan 2017 13:34:20 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/fully_exempt_line_item.yml
+++ b/spec/fixtures/vcr_cassettes/fully_exempt_line_item.yml
@@ -1,0 +1,100 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.taxjar.com/v2/nexus/regions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - TaxjarRubyGem/1.5.0
+      Authorization:
+      - Bearer 04d828b7374896d7867b03289ea20957
+      Connection:
+      - close
+      Host:
+      - api.taxjar.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Sun, 15 Jan 2017 15:18:28 GMT
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+      Vary:
+      - Origin
+      Etag:
+      - W/"447b75f14eaedf6b3e59ea269af620e4"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 709ad10b-83b8-4bf7-acc2-89a5885a52a3
+      X-Runtime:
+      - '0.213305'
+      Content-Length:
+      - '186'
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"regions":[{"country_code":"US","country":"United States","region_code":"CA","region":"California"},{"country_code":"US","country":"United
+        States","region_code":"TX","region":"Texas"}]}'
+    http_version: 
+  recorded_at: Sun, 15 Jan 2017 15:18:29 GMT
+- request:
+    method: post
+    uri: https://api.taxjar.com/v2/taxes
+    body:
+      encoding: UTF-8
+      string: '{"amount":"0.0","shipping":"0.0","to_state":"TX","to_zip":"79001","line_items":[{"id":1,"quantity":3,"unit_price":"10.0","discount":"0.0","product_tax_code":null},{"id":2,"quantity":3,"unit_price":"10.0","discount":"0.0","product_tax_code":"99999"}]}'
+    headers:
+      User-Agent:
+      - TaxjarRubyGem/1.5.0
+      Authorization:
+      - Bearer 04d828b7374896d7867b03289ea20957
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+      Host:
+      - api.taxjar.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Sun, 15 Jan 2017 15:18:32 GMT
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+      Vary:
+      - Origin
+      Etag:
+      - W/"a2385a180ae97ae003082f53cb3faca5"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 8cb44ed9-a931-4a66-ba21-e030002e5e22
+      X-Runtime:
+      - '0.049591'
+      Content-Length:
+      - '1759'
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"tax":{"order_total_amount":60.0,"shipping":0.0,"taxable_amount":30.0,"amount_to_collect":2.33,"rate":0.0775,"has_nexus":true,"freight_taxable":true,"tax_source":"origin","breakdown":{"taxable_amount":30.0,"tax_collectable":2.33,"combined_tax_rate":0.0775,"state_taxable_amount":30.0,"state_tax_rate":0.0625,"state_tax_collectable":1.88,"county_taxable_amount":30.0,"county_tax_rate":0.005,"county_tax_collectable":0.15,"city_taxable_amount":30.0,"city_tax_rate":0.01,"city_tax_collectable":0.3,"special_district_taxable_amount":0.0,"special_tax_rate":0.0,"special_district_tax_collectable":0.0,"shipping":{"taxable_amount":0.0,"tax_collectable":0.0,"combined_tax_rate":0.0775,"state_taxable_amount":0.0,"state_sales_tax_rate":0.0625,"state_amount":0.0,"county_taxable_amount":0.0,"county_tax_rate":0.005,"county_amount":0.0,"city_taxable_amount":0.0,"city_tax_rate":0.01,"city_amount":0.0,"special_taxable_amount":0.0,"special_tax_rate":0.0,"special_district_amount":0.0},"line_items":[{"id":"1","taxable_amount":30.0,"tax_collectable":2.33,"combined_tax_rate":0.0775,"state_taxable_amount":30.0,"state_sales_tax_rate":0.0625,"state_amount":1.88,"county_taxable_amount":30.0,"county_tax_rate":0.005,"county_amount":0.15,"city_taxable_amount":30.0,"city_tax_rate":0.01,"city_amount":0.3,"special_district_taxable_amount":0.0,"special_tax_rate":0.0,"special_district_amount":0.0},{"id":"2","taxable_amount":0.0,"tax_collectable":0.0,"combined_tax_rate":0.0,"state_taxable_amount":0.0,"state_sales_tax_rate":0.0,"state_amount":0.0,"county_taxable_amount":0.0,"county_tax_rate":0.0,"county_amount":0.0,"city_taxable_amount":0.0,"city_tax_rate":0.0,"city_amount":0.0,"special_district_taxable_amount":0.0,"special_tax_rate":0.0,"special_district_amount":0.0}]}}}'
+    http_version: 
+  recorded_at: Sun, 15 Jan 2017 15:18:32 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/fully_taxable_line_item.yml
+++ b/spec/fixtures/vcr_cassettes/fully_taxable_line_item.yml
@@ -1,0 +1,100 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.taxjar.com/v2/nexus/regions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - TaxjarRubyGem/1.5.0
+      Authorization:
+      - Bearer 04d828b7374896d7867b03289ea20957
+      Connection:
+      - close
+      Host:
+      - api.taxjar.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Sun, 15 Jan 2017 15:17:17 GMT
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+      Vary:
+      - Origin
+      Etag:
+      - W/"447b75f14eaedf6b3e59ea269af620e4"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - bcb35d19-d090-4807-8375-3b2d797c9aa9
+      X-Runtime:
+      - '0.011324'
+      Content-Length:
+      - '186'
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"regions":[{"country_code":"US","country":"United States","region_code":"CA","region":"California"},{"country_code":"US","country":"United
+        States","region_code":"TX","region":"Texas"}]}'
+    http_version: 
+  recorded_at: Sun, 15 Jan 2017 15:17:18 GMT
+- request:
+    method: post
+    uri: https://api.taxjar.com/v2/taxes
+    body:
+      encoding: UTF-8
+      string: '{"amount":"0.0","shipping":"0.0","to_state":"TX","to_zip":"79001","line_items":[{"id":1,"quantity":3,"unit_price":"10.0","discount":"0.0","product_tax_code":null},{"id":2,"quantity":3,"unit_price":"10.0","discount":"0.0","product_tax_code":"99999"}]}'
+    headers:
+      User-Agent:
+      - TaxjarRubyGem/1.5.0
+      Authorization:
+      - Bearer 04d828b7374896d7867b03289ea20957
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+      Host:
+      - api.taxjar.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Sun, 15 Jan 2017 15:17:19 GMT
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+      Vary:
+      - Origin
+      Etag:
+      - W/"a2385a180ae97ae003082f53cb3faca5"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 9f3b4da2-af9b-4f80-a756-3f6a1425b583
+      X-Runtime:
+      - '0.038290'
+      Content-Length:
+      - '1759'
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"tax":{"order_total_amount":60.0,"shipping":0.0,"taxable_amount":30.0,"amount_to_collect":2.33,"rate":0.0775,"has_nexus":true,"freight_taxable":true,"tax_source":"origin","breakdown":{"taxable_amount":30.0,"tax_collectable":2.33,"combined_tax_rate":0.0775,"state_taxable_amount":30.0,"state_tax_rate":0.0625,"state_tax_collectable":1.88,"county_taxable_amount":30.0,"county_tax_rate":0.005,"county_tax_collectable":0.15,"city_taxable_amount":30.0,"city_tax_rate":0.01,"city_tax_collectable":0.3,"special_district_taxable_amount":0.0,"special_tax_rate":0.0,"special_district_tax_collectable":0.0,"shipping":{"taxable_amount":0.0,"tax_collectable":0.0,"combined_tax_rate":0.0775,"state_taxable_amount":0.0,"state_sales_tax_rate":0.0625,"state_amount":0.0,"county_taxable_amount":0.0,"county_tax_rate":0.005,"county_amount":0.0,"city_taxable_amount":0.0,"city_tax_rate":0.01,"city_amount":0.0,"special_taxable_amount":0.0,"special_tax_rate":0.0,"special_district_amount":0.0},"line_items":[{"id":"1","taxable_amount":30.0,"tax_collectable":2.33,"combined_tax_rate":0.0775,"state_taxable_amount":30.0,"state_sales_tax_rate":0.0625,"state_amount":1.88,"county_taxable_amount":30.0,"county_tax_rate":0.005,"county_amount":0.15,"city_taxable_amount":30.0,"city_tax_rate":0.01,"city_amount":0.3,"special_district_taxable_amount":0.0,"special_tax_rate":0.0,"special_district_amount":0.0},{"id":"2","taxable_amount":0.0,"tax_collectable":0.0,"combined_tax_rate":0.0,"state_taxable_amount":0.0,"state_sales_tax_rate":0.0,"state_amount":0.0,"county_taxable_amount":0.0,"county_tax_rate":0.0,"county_amount":0.0,"city_taxable_amount":0.0,"city_tax_rate":0.0,"city_amount":0.0,"special_district_taxable_amount":0.0,"special_tax_rate":0.0,"special_district_amount":0.0}]}}}'
+    http_version: 
+  recorded_at: Sun, 15 Jan 2017 15:17:20 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/has_nexuses.yml
+++ b/spec/fixtures/vcr_cassettes/has_nexuses.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.taxjar.com/v2/nexus/regions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - TaxjarRubyGem/1.5.0
+      Authorization:
+      - Bearer 04d828b7374896d7867b03289ea20957
+      Connection:
+      - close
+      Host:
+      - api.taxjar.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Sun, 15 Jan 2017 17:39:01 GMT
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+      Vary:
+      - Origin
+      Etag:
+      - W/"447b75f14eaedf6b3e59ea269af620e4"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - c92e09e5-1aae-4e00-b904-d3761bfcc479
+      X-Runtime:
+      - '0.010771'
+      Content-Length:
+      - '186'
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"regions":[{"country_code":"US","country":"United States","region_code":"CA","region":"California"},{"country_code":"US","country":"United
+        States","region_code":"TX","region":"Texas"}]}'
+    http_version: 
+  recorded_at: Sun, 15 Jan 2017 17:39:03 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/no_nexuses.yml
+++ b/spec/fixtures/vcr_cassettes/no_nexuses.yml
@@ -1,0 +1,50 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.taxjar.com/v2/nexus/regions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - TaxjarRubyGem/1.5.0
+      Authorization:
+      - Bearer 04d828b7374896d7867b03289ea20957
+      Connection:
+      - close
+      Host:
+      - api.taxjar.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Sun, 15 Jan 2017 17:25:08 GMT
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+      Vary:
+      - Origin
+      Etag:
+      - W/"447b75f14eaedf6b3e59ea269af620e4"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 23c18e57-59da-40c5-b197-2d824987bdf5
+      X-Runtime:
+      - '0.010733'
+      Content-Length:
+      - '186'
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"regions":[]}'
+    http_version: 
+  recorded_at: Sun, 15 Jan 2017 17:25:09 GMT
+recorded_with: VCR 3.0.3

--- a/spec/models/spree/calculator/taxjar_calculator_spec.rb
+++ b/spec/models/spree/calculator/taxjar_calculator_spec.rb
@@ -2,29 +2,32 @@ require 'spec_helper'
 
 describe Spree::Calculator::TaxjarCalculator do
 
+  let!(:taxjar_exempt_tax_code) { "99999" }
   let!(:country) { create(:country) }
+  let!(:state) { create(:state, country: country, abbr: "TX") }
+  let!(:state_ca) { create(:state, country: country, abbr: "CA") }
   let!(:zone) { create(:zone, name: "Country Zone", default_tax: true, zone_members: []) }
-  let!(:ship_address) { create(:ship_address) }
+  let!(:ship_address) { create(:ship_address, city: "Adrian", zipcode: "79001", state: state) }
+  let!(:ship_address_ca) { create(:ship_address, city: "Los Angeles", zipcode: "90002", state: state_ca) }
   let!(:tax_category) { create(:tax_category, tax_rates: []) }
+  let!(:tax_category_exempt) { create(:tax_category, tax_rates: []) }
   let!(:rate) { create(:tax_rate, tax_category: tax_category, amount: 0.05, included_in_price: included_in_price) }
   let(:included_in_price) { false }
   let!(:calculator) { Spree::Calculator::TaxjarCalculator.new(calculable: rate) }
   let!(:order) { create(:order,ship_address_id: ship_address.id) }
-  let!(:line_item) { create(:line_item, price: 10, quantity: 3, tax_category: tax_category, order_id: order.id) }
-  let!(:shipment) { create(:shipment, cost: 15, order: order) }
+  let!(:line_item) { create(:line_item, price: 10, quantity: 3, order_id: order.id) }
+  let!(:line_item_exempt) { create(:line_item, price: 10, quantity: 3, order_id: order.id) }
+  let!(:shipment) { create(:shipment, cost: 10, order: order) }
+  let!(:order_ca) { create(:order,ship_address_id: ship_address_ca.id) }
+  let!(:line_item_ca) { create(:line_item, price: 10, quantity: 3, order_id: order_ca.id) }
+  let!(:shipment_ca) { create(:shipment, cost: 10, order: order_ca) }
   let!(:taxjar) { double(Taxjar::Client) }
   let(:taxjar_response) { double(Taxjar::Tax) }
 
   before do
-    Spree::Config[:taxjar_api_key] = '3d5b71689cf70fc393efb6cf2dd3dc9d'
+    Spree::Config[:taxjar_api_key] = '04d828b7374896d7867b03289ea20957'
     ## Forcing tests with shipping_address as tax_address
     Spree::Config[:tax_using_ship_address] = true
-    allow(Taxjar::Client).to receive(:new).with(api_key: '3d5b71689cf70fc393efb6cf2dd3dc9d').and_return(taxjar)
-    allow(taxjar).to receive(:nexus_regions).and_return([])
-    allow(taxjar).to receive(:tax_for_order).and_return(taxjar_response)
-    allow(taxjar_response).to receive(:[]).with('amount_to_collect').and_return(2.0)
-    allow(taxjar_response).to receive_message_chain(:breakdown, :line_items).and_return(order.line_items)
-    allow(line_item).to receive(:tax_collectable).and_return(2.0)
   end
 
   describe 'Constants' do
@@ -39,13 +42,7 @@ describe Spree::Calculator::TaxjarCalculator do
 
   describe "#compute_order" do
     it 'returns tax for the order upto two decimal places' do
-      expect(calculator.compute_order(order)).to eq(2.0)
-    end
-  end
-
-  describe "#tax_for_item" do
-    it 'returns tax for the line_item upto two decimal places' do
-      expect(calculator.send(:tax_for_item, line_item)).to eq(2.0)
+      expect{ calculator.compute_order(order)}.to raise_error(RuntimeError, 'Calculate tax for line_item and shipment and not order')
     end
   end
 
@@ -63,11 +60,21 @@ describe Spree::Calculator::TaxjarCalculator do
     context 'when taxjar calculation enabled' do
       before :each do
         Spree::Config[:taxjar_enabled] = true
+        tax_category_exempt.update_column(:tax_code, taxjar_exempt_tax_code)
+        line_item_exempt.update_column(:tax_category_id, tax_category_exempt.id)
       end
 
       context 'when rate not included in price' do
         it 'returns tax for the line_item upto two decimal places' do
-          expect(calculator.compute_line_item(line_item)).to eq(2.0)
+          VCR.use_cassette "fully_taxable_line_item" do
+            expect(calculator.compute_line_item(line_item)).to eq(2.33)
+          end
+        end
+
+        it 'should return ZERO tax for line_item having tax exempt code' do
+          VCR.use_cassette "fully_exempt_line_item" do
+            expect(calculator.compute_line_item(line_item_exempt)).to eq(0.0)
+          end
         end
       end
 
@@ -99,26 +106,20 @@ describe Spree::Calculator::TaxjarCalculator do
         Spree::Config[:taxjar_enabled] = true
       end
 
-      it 'should return tax on shipping' do
-        expect(calculator.compute_shipment(shipment)).to eq(0)
+      context 'Nexus charges tax on shipping' do
+        it 'should return tax on shipping' do
+          VCR.use_cassette "compute_shipment_with_texas_address" do
+            expect(calculator.compute_shipment(shipment)).to eq(0.78)
+          end
+        end
       end
-    end
-  end
 
-  describe '#compute_shipment_or_line_item' do
-    context 'when rate not included in price' do
-      it 'returns tax for the line_item/shipment upto two decimal places' do
-        expect(calculator.compute_shipment_or_line_item(line_item)).to eq(2.0)
-      end
-    end
-
-    context 'when rate included in price' do
-      before do
-        rate.included_in_price = true
-        rate.save
-      end
-      it 'returns tax for the line_item/shipment upto two decimal places' do
-        expect(calculator.compute_shipment_or_line_item(line_item)).to eq(0)
+      context 'Nexus charges NO tax on shipping' do
+        it 'should return tax on shipping as ZERO' do
+          VCR.use_cassette "compute_shipment_with_california_address" do
+            expect(calculator.compute_shipment(shipment_ca)).to eq(0)
+          end
+        end
       end
     end
   end
@@ -131,12 +132,24 @@ describe Spree::Calculator::TaxjarCalculator do
 
   describe '#compute_shipping_rate' do
     context 'when rate included in price' do
-      before do
-        rate.included_in_price = true
-        rate.save
+      context 'when taxjar calculation disabled' do
+        before :each do
+          Spree::Config[:taxjar_enabled] = false
+        end
+
+        it 'tax should be zero' do
+          expect(calculator.compute_shipment(shipment)).to eq(0)
+        end
       end
-      it 'will raise RuntimeError' do
-        expect{ calculator.compute_shipping_rate(line_item)}.to raise_error(RuntimeError)
+      context 'when taxjar calculation enabled' do
+        before do
+          rate.included_in_price = true
+          rate.save!
+          Spree::Config[:taxjar_enabled] = true
+        end
+        it 'will raise RuntimeError' do
+          expect{ calculator.compute_shipping_rate(line_item)}.to raise_error(RuntimeError)
+        end
       end
     end
     context 'when rate not included in price' do
@@ -144,34 +157,5 @@ describe Spree::Calculator::TaxjarCalculator do
         expect(calculator.compute_shipping_rate(line_item)).to eq(0.0)
       end
     end
-  end
-
-  describe '#cache_key' do
-    context 'when key is line item' do
-      it 'will return cache key for line item' do
-        expect(calculator.send(:cache_key, order, line_item, ship_address)).to eq(['Spree::LineItem', order.id, line_item.id, ship_address.state.id, ship_address.zipcode, line_item.amount, :amount_to_collect])
-      end
-    end
-    context 'when key is shipment' do
-      it 'will return cache key for line item' do
-        expect(calculator.send(:cache_key, order, shipment, ship_address)).to eq(['Spree::Shipment', order.id, shipment.id, ship_address.state.id, ship_address.zipcode, shipment.cost, :amount_to_collect])
-      end
-    end
-  end
-
-  describe '#cache_response' do
-    before do
-      @line_item = [{}]
-      allow(taxjar_response).to receive_message_chain(:breakdown, :line_items).and_return(@line_item)
-      allow(@line_item.first).to receive(:id).and_return(line_item.id)
-      allow(@line_item.first).to receive(:tax_collectable).and_return(2.0)
-    end
-    it 'sets Rails cache' do
-      calculator.send(:cache_response, taxjar_response, order, ship_address)
-      expect(Rails.cache.read(calculator.send(:cache_key, order, line_item, ship_address))).to eq 2.0
-    end
-
-    after { calculator.send(:cache_response, taxjar_response, order, ship_address) }
-
   end
 end

--- a/spec/models/spree/calculator/taxjar_calculator_spec.rb
+++ b/spec/models/spree/calculator/taxjar_calculator_spec.rb
@@ -11,7 +11,7 @@ describe Spree::Calculator::TaxjarCalculator do
   let!(:calculator) { Spree::Calculator::TaxjarCalculator.new(calculable: rate) }
   let!(:order) { create(:order,ship_address_id: ship_address.id) }
   let!(:line_item) { create(:line_item, price: 10, quantity: 3, tax_category: tax_category, order_id: order.id) }
-  let!(:shipment) { create(:shipment, cost: 15) }
+  let!(:shipment) { create(:shipment, cost: 15, order: order) }
   let!(:taxjar) { double(Taxjar::Client) }
   let(:taxjar_response) { double(Taxjar::Tax) }
 
@@ -46,6 +46,62 @@ describe Spree::Calculator::TaxjarCalculator do
   describe "#tax_for_item" do
     it 'returns tax for the line_item upto two decimal places' do
       expect(calculator.send(:tax_for_item, line_item)).to eq(2.0)
+    end
+  end
+
+  describe '#compute_line_item' do
+    context 'when taxjar calculation disabled' do
+      before :each do
+        Spree::Config[:taxjar_enabled] = false
+      end
+
+      it 'tax should be zero' do
+        expect(calculator.compute_line_item(line_item)).to eq(0)
+      end
+    end
+
+    context 'when taxjar calculation enabled' do
+      before :each do
+        Spree::Config[:taxjar_enabled] = true
+      end
+
+      context 'when rate not included in price' do
+        it 'returns tax for the line_item upto two decimal places' do
+          expect(calculator.compute_line_item(line_item)).to eq(2.0)
+        end
+      end
+
+      context 'when rate included in price' do
+        before do
+          rate.included_in_price = true
+          rate.save!
+        end
+        it 'returns tax for the line_item upto two decimal places' do
+          expect(calculator.compute_line_item(line_item)).to eq(0)
+        end
+      end
+    end
+  end
+
+  describe '#compute_shipment' do
+    context 'when taxjar calculation disabled' do
+      before :each do
+        Spree::Config[:taxjar_enabled] = false
+      end
+
+      it 'tax should be zero' do
+        expect(calculator.compute_shipment(shipment)).to eq(0)
+      end
+    end
+
+    context 'when taxjar calculation enabled' do
+      before :each do
+        Spree::Config[:taxjar_enabled] = true
+      end
+
+      it 'should return tax on shipping' do
+        expect(calculator.compute_shipment(shipment)).to eq(0)
+      end
     end
   end
 

--- a/spec/models/spree/order_decorator_spec.rb
+++ b/spec/models/spree/order_decorator_spec.rb
@@ -13,41 +13,82 @@ describe Spree::Order do
 
   describe 'Instance Methods' do
     describe '#delete_taxjar_transaction' do
-      context 'when taxjar_applicable? returns false' do
-        it 'should return nil' do
-          expect(order.send(:delete_taxjar_transaction)).to eq nil
+      context 'when taxjar calculation disabled' do
+        before :each do
+          Spree::Config[:taxjar_enabled] = false
         end
-      end
-      context 'when taxjar_applicable? return true' do
-        before do
-          allow(order).to receive(:taxjar_applicable?).with(order).and_return(true)
-          allow(Spree::Taxjar).to receive(:new).with(order).and_return(client)
-          allow(client).to receive(:delete_transaction_for_order)
-        end
-        it 'should delete transaction for order' do
-          expect(client).to receive(:delete_transaction_for_order)
+
+        it 'tax should be zero' do
+          expect(order).to_not receive(:taxjar_applicable?)
         end
 
         after { order.send(:delete_taxjar_transaction) }
       end
+
+      context 'when taxjar calculation enabled' do
+        before :each do
+          Spree::Config[:taxjar_enabled] = true
+        end
+
+        context 'when taxjar_applicable? returns false' do
+          it 'should return nil' do
+            expect(order.send(:delete_taxjar_transaction)).to eq nil
+          end
+        end
+
+        context 'when taxjar_applicable? return true' do
+          before do
+            allow(order).to receive(:taxjar_applicable?).with(order).and_return(true)
+            allow(Spree::Taxjar).to receive(:new).with(order).and_return(client)
+            allow(client).to receive(:delete_transaction_for_order)
+          end
+
+          it 'should delete transaction for order' do
+            expect(client).to receive(:delete_transaction_for_order)
+          end
+
+          after { order.send(:delete_taxjar_transaction) }
+        end
+      end
     end
 
     describe '#capture_taxjar' do
-      context 'when taxjar_applicable? returns false' do
-        it 'should return nil' do
-          expect(order.send(:capture_taxjar)).to eq nil
+      context 'when taxjar calculation disabled' do
+        before :each do
+          Spree::Config[:taxjar_enabled] = false
         end
-      end
-      context 'when taxjar_applicable? return true' do
-        before do
-          allow(order).to receive(:taxjar_applicable?).with(order).and_return(true)
-          allow(Spree::Taxjar).to receive(:new).with(order).and_return(client)
-          allow(client).to receive(:create_transaction_for_order)
+
+        it 'tax should be zero' do
+          expect(order).to_not receive(:taxjar_applicable?)
         end
-        it 'should create transaction for order' do
-          expect(client).to receive(:create_transaction_for_order)
-        end
+
         after { order.send(:capture_taxjar) }
+      end
+
+      context 'when taxjar calculation enabled' do
+        before :each do
+          Spree::Config[:taxjar_enabled] = true
+        end
+
+        context 'when taxjar_applicable? returns false' do
+          it 'should return nil' do
+            expect(order.send(:capture_taxjar)).to eq nil
+          end
+        end
+
+        context 'when taxjar_applicable? return true' do
+          before do
+            allow(order).to receive(:taxjar_applicable?).with(order).and_return(true)
+            allow(Spree::Taxjar).to receive(:new).with(order).and_return(client)
+            allow(client).to receive(:create_transaction_for_order)
+          end
+
+          it 'should create transaction for order' do
+            expect(client).to receive(:create_transaction_for_order)
+          end
+
+          after { order.send(:capture_taxjar) }
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,8 @@ require 'rspec/rails'
 require 'database_cleaner'
 require 'ffaker'
 require 'rspec/active_model/mocks'
+require 'vcr'
+
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
 Dir[File.join(File.dirname(__FILE__), 'support/**/*.rb')].each { |f| require f }
@@ -92,4 +94,11 @@ RSpec.configure do |config|
 
   config.fail_fast = ENV['FAIL_FAST'] || false
   config.order = "random"
+  config.extend VCR::RSpec::Macros
+end
+
+VCR.configure do |c|
+  c.cassette_library_dir = 'spec/fixtures/vcr_cassettes'
+  c.hook_into :webmock
+  c.allow_http_connections_when_no_cassette = true
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -94,11 +94,11 @@ RSpec.configure do |config|
 
   config.fail_fast = ENV['FAIL_FAST'] || false
   config.order = "random"
-  config.extend VCR::RSpec::Macros
 end
 
 VCR.configure do |c|
   c.cassette_library_dir = 'spec/fixtures/vcr_cassettes'
   c.hook_into :webmock
   c.allow_http_connections_when_no_cassette = true
+  c.configure_rspec_metadata!
 end

--- a/spree_taxjar.gemspec
+++ b/spree_taxjar.gemspec
@@ -29,4 +29,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'sqlite3', '~> 1.3.11'
   s.add_development_dependency 'shoulda-matchers'
   s.add_development_dependency 'rspec-activemodel-mocks'
+  s.add_development_dependency 'vcr'
+  s.add_development_dependency 'webmock'
 end


### PR DESCRIPTION
- There are N + 1 calls made for each order with N shipments.
  - N calls to get shipment sales tax and 1 for Order line items
- Enables logging to a separate file and Rails log through Spree `taxjar_debug_enabled` preference
- Enables taxjar calculation through Spree `taxjar_enabled` preference and returns either 0 or no effect when disabled
- `vcr` and `webmock` gems are used to stub http call requests and avoid mocking on objects for expectations

This PR caters to #18 and #16 also