### PR TITLE
Update factory_girl to factory_bot

### DIFF
--- a/lib/spree_taxjar/factories.rb
+++ b/lib/spree_taxjar/factories.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   # Define your Spree extensions Factories within this file to enable applications, and other extensions to use and override them.
   #
   # Example adding this to your spec_helper will load these Factories for use:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,7 +38,7 @@ require 'spree/testing_support/url_helpers'
 require 'spree_taxjar/factories'
 
 RSpec.configure do |config|
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
 
   # Infer an example group's spec type from the file location.
   config.infer_spec_type_from_file_location!

--- a/spree_taxjar.gemspec
+++ b/spree_taxjar.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'capybara', '~> 2.6'
   s.add_development_dependency 'coffee-rails', '~> 4.2.1'
   s.add_development_dependency 'database_cleaner', '~> 1.5.3'
-  s.add_development_dependency 'factory_girl', '~> 4.5'
+  s.add_development_dependency 'factory_bot', '~> 4.10'
   s.add_development_dependency 'ffaker', '~> 2.2.0'
   s.add_development_dependency 'rspec-rails', '~> 3.4'
   s.add_development_dependency 'sass-rails', '~> 5.0.0'


### PR DESCRIPTION
spree uses the latter gem name, which breaks specs from
(at least, from a newly created dummy app).

One issue I also encountered is that this breaks in spree-3-2.

It might be because the generated dummy app is in rails 5.1 when `bundle exec rake` is run (to generate the spec/dummy app) and then `bundle exec appraisal spree-3.2 rake` runs the specs:

```sh
An error occurred while loading ./spec/models/spree/taxjar_spec.rb.
Failure/Error: config.load_defaults 5.1

NoMethodError:
  undefined method `load_defaults' for #<Rails::Application::Configuration:0x00007f8012435c30>
# ./spec/dummy/config/application.rb:43:in `<class:Application>'
# ./spec/dummy/config/application.rb:28:in `<module:Dummy>'
# ./spec/dummy/config/application.rb:27:in `<top (required)>'
# ./spec/dummy/config/environment.rb:2:in `require_relative'
# ./spec/dummy/config/environment.rb:2:in `<top (required)>'
# ./spec/spec_helper.rb:16:in `<top (required)>'
# ./spec/models/spree/taxjar_spec.rb:1:in `<top (required)>'
No examples found.
```

But in spree-3-3 and spree-3-4, this works fine.