### PR TITLE
Upgrade taxjar-ruby from ~> 1.5 (latest: 1.7.1) to 2.0.0, which upgrades http gem

### DIFF
--- a/spree_taxjar.gemspec
+++ b/spree_taxjar.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   spree_version = '>= 3.2.0', '< 4.0.0'
 
   s.add_dependency 'spree_core', spree_version
-  s.add_dependency 'taxjar-ruby', '~> 1.5'
+  s.add_dependency 'taxjar-ruby', '~> 2.0.0'
 
   s.add_development_dependency 'capybara', '~> 2.6'
   s.add_development_dependency 'coffee-rails', '~> 4.2.1'


### PR DESCRIPTION
... which just upgrades http gem to 2.0 from 1.0.4

See the taxjar-ruby diff:
1.7.1 -> 2.0.0: https://github.com/taxjar/taxjar-ruby/compare/v1.7.1...v2.0.0
1.5.0 -> 2.0.0: https://github.com/taxjar/taxjar-ruby/compare/v1.5.0...v2.0.0

-----------

I needed to do this to upgrade to the `http` gem to 2.0 (since other gems require at least 2.0)